### PR TITLE
patch geos

### DIFF
--- a/apache-orc/PKGBUILD
+++ b/apache-orc/PKGBUILD
@@ -3,7 +3,7 @@
 
 _pkg=orc
 pkgname=apache-${_pkg}
-pkgver=1.8.1
+pkgver=1.8.3
 pkgrel=1
 pkgdesc="Columnar storage for Hadoop workloads."
 arch=(loong64 x86_64)
@@ -12,9 +12,8 @@ license=(Apache)
 depends=(lz4 protobuf snappy zlib zstd)
 makedepends=(cmake)
 checkdepends=(gtest)
-source=(https://dlcdn.apache.org/${_pkg}/${_pkg}-${pkgver}/${_pkg}-${pkgver}.tar.gz{,.asc})
-sha256sums=(ba5877bd737e1fbc69822d3861b8e84854640bf2439b7ddad536d6303dd3638d SKIP)
-validpgpkeys=(F28C9C925C188C35E345614DEDA00CE834F0FC5C) # Dongjoon Hyun (CODE SIGNING KEY) <dongjoon@apache.org>
+source=(https://dlcdn.apache.org/${_pkg}/${_pkg}-${pkgver}/${_pkg}-${pkgver}.tar.gz)
+sha256sums=('a78678ec425c8129d63370cb8a9bacb54186aa66af1e2bec01ce92e7eaf72e20')
 
 prepare(){
   cd ${_pkg}-${pkgver}
@@ -38,7 +37,8 @@ build(){
     -DORC_PREFER_STATIC_ZLIB=OFF \
     -DBUILD_LIBHDFSPP=OFF \
     -DBUILD_JAVA=OFF \
-    -DINSTALL_VENDORED_LIBS=OFF
+    -DINSTALL_VENDORED_LIBS=OFF \
+    -DSTOP_BUILD_ON_WARNING=OFF
   make -C build
 }
 

--- a/geos/PKGBUILD
+++ b/geos/PKGBUILD
@@ -5,7 +5,7 @@
 # Contributor: Alexander Rødseth <rodseth@gmail.com>
 
 pkgname=geos
-pkgver=3.11.1
+pkgver=3.11.2
 pkgrel=1
 pkgdesc="C/C++ library for computational geometry"
 arch=(loong64 x86_64)
@@ -15,8 +15,14 @@ depends=(gcc-libs bash)
 makedepends=(cmake)
 options=(!emptydirs)
 changelog=$pkgname.changelog
-source=(https://download.osgeo.org/$pkgname/$pkgname-$pkgver.tar.bz2)
-sha256sums=('6d0eb3cfa9f92d947731cc75f1750356b3bdfc07ea020553daf6af1c768e0be2')
+source=(https://download.osgeo.org/$pkgname/$pkgname-$pkgver.tar.bz2
+	$pkgname-$pkgver-gcc13.patch)
+sha256sums=('b1f077669481c5a3e62affc49e96eb06f281987a5d36fdab225217e5b825e4cc'
+            '87e5de84683f2183e593b9578539a36ba39f43c07f79f9f6b09b0faeb972c25e')
+
+prepare(){
+  patch -Np1 -i  ./$pkgname-$pkgver-gcc13.patch
+}
 
 build() {
   cmake -B build -S $pkgname-$pkgver \

--- a/geos/PKGBUILD
+++ b/geos/PKGBUILD
@@ -6,7 +6,7 @@
 
 pkgname=geos
 pkgver=3.11.2
-pkgrel=1
+pkgrel=2
 pkgdesc="C/C++ library for computational geometry"
 arch=(loong64 x86_64)
 url="https://libgeos.org/"

--- a/geos/geos-3.11.2-gcc13.patch
+++ b/geos/geos-3.11.2-gcc13.patch
@@ -1,0 +1,23 @@
+diff -Naur src/geos-3.11.2/include/geos/shape/fractal/HilbertEncoder.h src/geos-3.11.2/include/geos/shape/fractal/HilbertEncoder.h
+--- src/geos-3.11.2/include/geos/shape/fractal/HilbertEncoder.h	2023-03-28 19:32:13.476662911 +0800
++++ src/geos-3.11.2/include/geos/shape/fractal/HilbertEncoder.h	2023-03-28 19:34:15.021935510 +0800
+@@ -18,6 +18,7 @@
+ #include <geos/export.h>
+ #include <string>
+ #include <vector>
++#include <cstdint>
+ 
+ // Forward declarations
+ namespace geos {
+diff -Naur src/geos-3.11.2/tests/unit/capi/GEOSMakeValidTest.cpp src/geos-3.11.2/tests/unit/capi/GEOSMakeValidTest.cpp
+--- src/geos-3.11.2/tests/unit/capi/GEOSMakeValidTest.cpp	2023-03-28 19:32:13.992668278 +0800
++++ src/geos-3.11.2/tests/unit/capi/GEOSMakeValidTest.cpp	2023-03-28 19:35:04.686459884 +0800
+@@ -9,7 +9,7 @@
+ #include <cstdlib>
+ #include <cmath>
+ #include <cstring>
+-
++#include <cstdint>
+ #include "capi_test_utils.h"
+ 
+ namespace tut {

--- a/geos/geos.changelog
+++ b/geos/geos.changelog
@@ -1,3 +1,6 @@
+2023-03-28 airscrat <hsq2013@163.com>
+	*geos 3.11.2-1
+
 2022-06-27 Bruno Pagani <archange@archlinux.org
 	* geos 3.10.3-1
 


### PR DESCRIPTION
Hi yetist, thank u for your efforts on Loongarch Linux! There is many pkgs depends on geos , such as gdal,libspatialite etc. So, I have fixed two compilation errors when building with gcc 13. It can be compiled correctly now.